### PR TITLE
Rename 'middlware' to 'middleware' for consistency in roles config.

### DIFF
--- a/src/App/Http/Requests/StorePermissionRequest.php
+++ b/src/App/Http/Requests/StorePermissionRequest.php
@@ -13,11 +13,11 @@ class StorePermissionRequest extends FormRequest
      */
     public function authorize()
     {
-        if (config('roles.rolesGuiCreateNewPermissionMiddlwareType') == 'role') {
-            return $this->user()->hasRole(config('roles.rolesGuiCreateNewPermissionsMiddlware'));
+        if (config('roles.rolesGuiCreateNewPermissionMiddlewareType') == 'role') {
+            return $this->user()->hasRole(config('roles.rolesGuiCreateNewPermissionsMiddleware'));
         }
-        if (config('roles.rolesGuiCreateNewPermissionMiddlwareType') == 'permissions') {
-            return $this->user()->hasPermission(config('roles.rolesGuiCreateNewPermissionsMiddlware'));
+        if (config('roles.rolesGuiCreateNewPermissionMiddlewareType') == 'permissions') {
+            return $this->user()->hasPermission(config('roles.rolesGuiCreateNewPermissionsMiddleware'));
         }
 
         return true;

--- a/src/App/Http/Requests/StoreRoleRequest.php
+++ b/src/App/Http/Requests/StoreRoleRequest.php
@@ -13,11 +13,11 @@ class StoreRoleRequest extends FormRequest
      */
     public function authorize()
     {
-        if (config('roles.rolesGuiCreateNewRolesMiddlwareType') == 'role') {
-            return $this->user()->hasRole(config('roles.rolesGuiCreateNewRolesMiddlware'));
+        if (config('roles.rolesGuiCreateNewRolesMiddlewareType') == 'role') {
+            return $this->user()->hasRole(config('roles.rolesGuiCreateNewRolesMiddleware'));
         }
-        if (config('roles.rolesGuiCreateNewRolesMiddlwareType') == 'permissions') {
-            return $this->user()->hasPermission(config('roles.rolesGuiCreateNewRolesMiddlware'));
+        if (config('roles.rolesGuiCreateNewRolesMiddlewareType') == 'permissions') {
+            return $this->user()->hasPermission(config('roles.rolesGuiCreateNewRolesMiddleware'));
         }
 
         return true;

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -112,12 +112,12 @@ return [
     'rolesGuiMiddleware'            => env('ROLES_GUI_MIDDLEWARE', 'role:admin'),
 
     // User Permissions or Role needed to create a new role
-    'rolesGuiCreateNewRolesMiddlwareType'   => env('ROLES_GUI_CREATE_ROLE_MIDDLWARE_TYPE', 'role'), //permissions or roles
-    'rolesGuiCreateNewRolesMiddlware'       => env('ROLES_GUI_CREATE_ROLE_MIDDLWARE_TYPE', 'admin'), // admin, XXX. ... or perms.XXX
+    'rolesGuiCreateNewRolesMiddlewareType'   => env('ROLES_GUI_CREATE_ROLE_MIDDLEWARE_TYPE', 'role'), //permissions or roles
+    'rolesGuiCreateNewRolesMiddleware'       => env('ROLES_GUI_CREATE_ROLE_MIDDLEWARE_TYPE', 'admin'), // admin, XXX. ... or perms.XXX
 
     // User Permissions or Role needed to create a new permission
-    'rolesGuiCreateNewPermissionMiddlwareType'  => env('ROLES_GUI_CREATE_PERMISSION_MIDDLWARE_TYPE', 'role'), //permissions or roles
-    'rolesGuiCreateNewPermissionsMiddlware'     => env('ROLES_GUI_CREATE_PERMISSION_MIDDLWARE_TYPE', 'admin'), // admin, XXX. ... or perms.XXX
+    'rolesGuiCreateNewPermissionMiddlewareType'  => env('ROLES_GUI_CREATE_PERMISSION_MIDDLEWARE_TYPE', 'role'), //permissions or roles
+    'rolesGuiCreateNewPermissionsMiddleware'     => env('ROLES_GUI_CREATE_PERMISSION_MIDDLEWARE_TYPE', 'admin'), // admin, XXX. ... or perms.XXX
 
     // The parent blade file
     'bladeExtended'                 => env('ROLES_GUI_BLADE_EXTENDED', 'layouts.app'),


### PR DESCRIPTION
Considering if the config lookup should check for the old name before going for default, if there is a lot of backwards compatibility to worry about.