### PR TITLE
Use table names from config in relationship tables' migrations

### DIFF
--- a/src/Database/Migrations/2016_01_15_114412_create_role_user_table.php
+++ b/src/Database/Migrations/2016_01_15_114412_create_role_user_table.php
@@ -15,13 +15,14 @@ class CreateRoleUserTable extends Migration
     {
         $connection = config('roles.connection');
         $table = config('roles.roleUserTable');
+        $rolesTable = config('roles.rolesTable');
         $tableCheck = Schema::connection($connection)->hasTable($table);
 
         if (!$tableCheck) {
-            Schema::connection($connection)->create($table, function (Blueprint $table) {
+            Schema::connection($connection)->create($table, function (Blueprint $table) use ($rolesTable) {
                 $table->increments('id')->unsigned();
                 $table->integer('role_id')->unsigned()->index();
-                $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+                $table->foreign('role_id')->references('id')->on($rolesTable)->onDelete('cascade');
                 $table->unsignedBigInteger('user_id')->unsigned()->index();
                 $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
                 $table->timestamps();

--- a/src/Database/Migrations/2016_01_26_115523_create_permission_role_table.php
+++ b/src/Database/Migrations/2016_01_26_115523_create_permission_role_table.php
@@ -15,15 +15,17 @@ class CreatePermissionRoleTable extends Migration
     {
         $connection = config('roles.connection');
         $table = config('roles.permissionsRoleTable');
+        $permissionsTable = config('roles.permissionsTable');
+        $rolesTable = config('roles.rolesTable');
         $tableCheck = Schema::connection($connection)->hasTable($table);
 
         if (!$tableCheck) {
-            Schema::connection($connection)->create($table, function (Blueprint $table) {
+            Schema::connection($connection)->create($table, function (Blueprint $table) use ($permissionsTable, $rolesTable) {
                 $table->increments('id')->unsigned();
                 $table->integer('permission_id')->unsigned()->index();
-                $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+                $table->foreign('permission_id')->references('id')->on($permissionsTable)->onDelete('cascade');
                 $table->integer('role_id')->unsigned()->index();
-                $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+                $table->foreign('role_id')->references('id')->on($rolesTable)->onDelete('cascade');
                 $table->timestamps();
                 $table->softDeletes();
             });

--- a/src/Database/Migrations/2016_02_09_132439_create_permission_user_table.php
+++ b/src/Database/Migrations/2016_02_09_132439_create_permission_user_table.php
@@ -15,13 +15,14 @@ class CreatePermissionUserTable extends Migration
     {
         $connection = config('roles.connection');
         $table = config('roles.permissionsUserTable');
+        $permissionsTable = config('roles.permissionsTable');
         $tableCheck = Schema::connection($connection)->hasTable($table);
 
         if (!$tableCheck) {
-            Schema::connection($connection)->create($table, function (Blueprint $table) {
+            Schema::connection($connection)->create($table, function (Blueprint $table) use ($permissionsTable) {
                 $table->increments('id')->unsigned();
                 $table->integer('permission_id')->unsigned()->index();
-                $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+                $table->foreign('permission_id')->references('id')->on($permissionsTable)->onDelete('cascade');
                 $table->unsignedBigInteger('user_id')->unsigned()->index();
                 $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
                 $table->timestamps();


### PR DESCRIPTION
Use table names from config in relationship tables' migrations,
in case they have been changed in config file.