### PR TITLE
Explicitly named timestamp columns

### DIFF
--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -34,7 +34,7 @@ trait HasRoleAndPermission
      */
     public function roles()
     {
-        return $this->belongsToMany(config('roles.models.role'))->withTimestamps();
+        return $this->belongsToMany(config('roles.models.role'))->withTimestamps('created_at', 'updated_at');
     }
 
     /**
@@ -214,7 +214,7 @@ trait HasRoleAndPermission
      */
     public function userPermissions()
     {
-        return $this->belongsToMany(config('roles.models.permission'))->withTimestamps();
+        return $this->belongsToMany(config('roles.models.permission'))->withTimestamps('created_at', 'updated_at');
     }
 
     /**


### PR DESCRIPTION
After using the HasRoleAndPermission trait on my User model with custom names for timestamp columns I was unable to query the roles. The custom names get also applied to the pivot tables in belongsToMany relationships. To avoid this actual name columns have to be specified, otherwise a query exceptions occurs.
The actual name columns are now specified in the relation and match the ones generated in the default migrations. https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/Blueprint.php#L982