### PR TITLE
migrations-toggle: re: issue 76 & 40

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ ROLES_PERMISSION_USER_DATABASE_TABLE=permission_user
 # Roles Misc Settings
 ROLES_DEFAULT_SEPARATOR='.'
 
+# Roles Database Migrations Settings
+ROLES_MIGRATION_DEFAULT_ENABLED=true
+
 # Roles Database Seeder Settings
 ROLES_SEED_DEFAULT_PERMISSIONS=true
 ROLES_SEED_DEFAULT_ROLES=true

--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -63,6 +63,7 @@ class RolesServiceProvider extends ServiceProvider
             $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
         }
     }
+
     /**
      * Loads a seeds.
      *

--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -57,7 +57,8 @@ class RolesServiceProvider extends ServiceProvider
         $this->loadSeedsFrom();
     }
 
-    private function loadMigrations() {
+    private function loadMigrations() 
+    {
         if (config('roles.defaultMigrations.enabled')) {
             $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
         }

--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -57,7 +57,7 @@ class RolesServiceProvider extends ServiceProvider
         $this->loadSeedsFrom();
     }
 
-    private function loadMigrations() 
+    private function loadMigrations()
     {
         if (config('roles.defaultMigrations.enabled')) {
             $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');

--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -49,7 +49,7 @@ class RolesServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/config/roles.php', 'roles');
-        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
+        $this->loadMigrations();
         if (config('roles.rolesGuiEnabled')) {
             $this->loadViewsFrom(__DIR__.'/resources/views/', $this->_packageTag);
         }
@@ -57,6 +57,11 @@ class RolesServiceProvider extends ServiceProvider
         $this->loadSeedsFrom();
     }
 
+    private function loadMigrations() {
+        if (config('roles.defaultMigrations.enabled')) {
+            $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
+        }
+    }
     /**
      * Loads a seeds.
      *

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -81,7 +81,7 @@ return [
     */
 
     'defaultMigrations' => [
-        'enabled'        => env('ROLES_MIGRATION_DEFAULT_ENABLED', false)
+        'enabled'        => env('ROLES_MIGRATION_DEFAULT_ENABLED', false),
     ],
     /*
     |--------------------------------------------------------------------------

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -69,7 +69,20 @@ return [
             'allowed'       => true,
         ],
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Default Migrations
+    |--------------------------------------------------------------------------
+    |
+    | These are the default package migrations. If you publish the migrations 
+    | to your project, then this is not necessary and should be disabled. This
+    | will enable our default migrations.
+    |
+    */
 
+    'defaultMigrations' => [
+        'enabled'        => env('ROLES_MIGRATION_DEFAULT_ENABLED', false)
+    ],
     /*
     |--------------------------------------------------------------------------
     | Default Seeds

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -74,7 +74,7 @@ return [
     | Default Migrations
     |--------------------------------------------------------------------------
     |
-    | These are the default package migrations. If you publish the migrations 
+    | These are the default package migrations. If you publish the migrations
     | to your project, then this is not necessary and should be disabled. This
     | will enable our default migrations.
     |


### PR DESCRIPTION
Currently, when you follow the instructions for configuring laravel-roles, migrations are copied from laravel-roles to the users project. 

When the migration is run the migration then tries to run migrations from both the laravel-roles Migration folder and the users migration folders. Complicating things is that the timestamp on the laravel-roles migrations are dated 2016 so they tend to run first which on newer projects creates an issue with tables/attributes not being found.

This PR allows users to toggle the migrations in laravel-roles.