### PR TITLE
Fix route middleware namespaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -510,9 +510,9 @@ protected $routeMiddleware = [
     'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
     'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-    'role'          => \jeremykenedy\LaravelRoles\Middleware\VerifyRole::class,
-    'permission'    => \jeremykenedy\LaravelRoles\Middleware\VerifyPermission::class,
-    'level'         => \jeremykenedy\LaravelRoles\Middleware\VerifyLevel::class,
+    'role' => \jeremykenedy\LaravelRoles\App\Http\Middleware\VerifyRole::class,
+    'permission' => \jeremykenedy\LaravelRoles\App\Http\Middleware\VerifyPermission::class,
+    'level' => \jeremykenedy\LaravelRoles\App\Http\Middleware\VerifyLevel::class,
 ];
 ```
 


### PR DESCRIPTION
The namespaces in the `readme.md` file seem to be outdated.