### PR TITLE
Fix: First try to get the Admin role by 'slug'. If that fails, try to get it by 'name', as for backwards compatibility

### DIFF
--- a/src/Database/Seeds/DefaultConnectRelationshipsSeeder.php
+++ b/src/Database/Seeds/DefaultConnectRelationshipsSeeder.php
@@ -21,7 +21,9 @@ class DefaultConnectRelationshipsSeeder extends Seeder
         /**
          * Attach Permissions to Roles.
          */
-        $roleAdmin = config('roles.models.role')::where('name', '=', 'Admin')->first();
+        $roleAdmin = config('roles.models.role')::where('slug', '=', 'admin')->first()
+            ?? config('roles.models.role')::where('name', '=', 'Admin')->first();
+
         echo "\e[32mSeeding:\e[0m DefaultConnectRelationshipsSeeder\r\n";
         foreach ($permissions as $permission) {
             $roleAdmin->attachPermission($permission);


### PR DESCRIPTION
See issue: https://github.com/jeremykenedy/laravel-roles/issues/103