### PR TITLE
Fix pivot table name (`role_user`). 

### DIFF
--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -34,7 +34,7 @@ trait HasRoleAndPermission
      */
     public function roles()
     {
-        return $this->belongsToMany(config('roles.models.role'))->withTimestamps();
+        return $this->belongsToMany(config('roles.models.role'), config('roles.roleUserTable'))->withTimestamps();
     }
 
     /**

--- a/src/Traits/RoleHasRelations.php
+++ b/src/Traits/RoleHasRelations.php
@@ -24,7 +24,7 @@ trait RoleHasRelations
      */
     public function users()
     {
-        return $this->belongsToMany(config('roles.models.defaultUser'))->withTimestamps();
+        return $this->belongsToMany(config('roles.models.defaultUser'), config('roles.roleUserTable'))->withTimestamps();
     }
 
     /**


### PR DESCRIPTION
The table name is now used from the configuration.

.env
`ROLES_ROLE_USER_DATABASE_TABLE='my_pivot_role_user_table'`

Now it works!

Fix PR
https://github.com/jeremykenedy/laravel-roles/issues/94
https://github.com/jeremykenedy/laravel-roles/issues/93