### PR TITLE
Fix for postgresql error

### DIFF
--- a/src/App/Http/Requests/StorePermissionRequest.php
+++ b/src/App/Http/Requests/StorePermissionRequest.php
@@ -31,8 +31,8 @@ class StorePermissionRequest extends FormRequest
     public function rules()
     {
         return [
-            'name'          => 'required|max:60|unique:'.config('roles.permissionsTable').',name,'.$this->id.',id',
-            'slug'          => 'required|max:60|unique:'.config('roles.permissionsTable').',slug,'.$this->id.',id',
+            'name'          => 'required|max:60|unique:'.config('roles.permissionsTable').',name,'.$this->id,
+            'slug'          => 'required|max:60|unique:'.config('roles.permissionsTable').',slug,'.$this->id,
             'description'   => 'nullable|string|max:255',
             'model'         => 'required|string|max:60',
         ];

--- a/src/App/Http/Requests/StoreRoleRequest.php
+++ b/src/App/Http/Requests/StoreRoleRequest.php
@@ -31,8 +31,8 @@ class StoreRoleRequest extends FormRequest
     public function rules()
     {
         return [
-            'name'          => 'required|unique:'.config('roles.rolesTable').',name,'.$this->id.',id',
-            'slug'          => 'required|unique:'.config('roles.rolesTable').',slug,'.$this->id.',id',
+            'name'          => 'required|unique:'.config('roles.rolesTable').',name,'.$this->id,
+            'slug'          => 'required|unique:'.config('roles.rolesTable').',slug,'.$this->id,
             'description'   => 'nullable|string|max:255',
             'level'         => 'required|integer',
         ];


### PR DESCRIPTION
fix for postgresql "Invalid text representation: 7 ERROR: invalid input syntax for integer:...." error.