### PR TITLE
Allow for disabling of inheritance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ A Powerful package for handling roles and permissions in Laravel. Supports Larav
     - [Creating Permissions](#creating-permissions)
     - [Attaching, Detaching and Syncing Permissions](#attaching-detaching-and-syncing-permissions)
     - [Checking For Permissions](#checking-for-permissions)
-    - [Permissions Inheriting](#permissions-inheriting)
+    - [Permissions Inheritance](#permissions-inheritance)
     - [Entity Check](#entity-check)
     - [Blade Extensions](#blade-extensions)
     - [Middleware](#middleware)
@@ -418,15 +418,15 @@ if ($user->canDeleteUsers()) {
 
 You can check for multiple permissions the same way as roles. You can make use of additional methods like `hasOnePermission` or `hasAllPermissions`.
 
-### Permissions Inheriting
+### Permissions Inheritance
 
-Role with higher level is inheriting permission from roles with lower level.
+By default, roles with higher level inherit all permissions from roles with lower level.
 
-There is an example of this `magic`:
+For example:
 
-You have three roles: `user`, `moderator` and `admin`. User has a permission to read articles, moderator can manage comments and admin can create articles. User has a level 1, moderator level 2 and admin level 3. It means, moderator and administrator has also permission to read articles, but administrator can manage comments as well.
+You have three roles: `user`, `moderator` and `admin`. User has a permission to read articles, moderator can manage comments and admin can create articles. User has a level 1, moderator level 2 and admin level 3. With inheritance enabled, moderator and administrator also have the permission to read articles, and administrator can manage comments as well.
 
-> If you don't want permissions inheriting feature in you application, simply ignore `level` parameter when you're creating roles.
+> If you don't want the permissions inheritance feature enabled in you application, set the config value roles.inheritance (or its corresponding .env parameter, ROLES_INHERITANCE) to false. Alternatively, simply ignore the `level` parameter when you're creating roles.
 
 ### Entity Check
 

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -199,13 +199,24 @@ trait HasRoleAndPermission
             throw new InvalidArgumentException('[roles.models.permission] must be an instance of \Illuminate\Database\Eloquent\Model');
         }
 
-        return $permissionModel
-            ::select(['permissions.*', 'permission_role.created_at as pivot_created_at', 'permission_role.updated_at as pivot_updated_at'])
-            ->join('permission_role', 'permission_role.permission_id', '=', 'permissions.id')
-            ->join($roleTable, $roleTable.'.id', '=', 'permission_role.role_id')
-            ->whereIn($roleTable.'.id', $this->getRoles()->pluck('id')->toArray())
-            ->orWhere($roleTable.'.level', '<', $this->level())
-            ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'permissions.deleted_at', 'pivot_created_at', 'pivot_updated_at']);
+        if(config('roles.inheritance')) {
+            return $permissionModel
+                ::select(['permissions.*', 'permission_role.created_at as pivot_created_at', 'permission_role.updated_at as pivot_updated_at'])
+                ->join('permission_role', 'permission_role.permission_id', '=', 'permissions.id')
+                ->join($roleTable, $roleTable . '.id', '=', 'permission_role.role_id')
+                ->whereIn($roleTable . '.id', $this->getRoles()->pluck('id')->toArray())
+                ->orWhere($roleTable . '.level', '<', $this->level())
+                ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'permissions.deleted_at', 'pivot_created_at', 'pivot_updated_at']);
+        }
+        else
+        {
+            return $permissionModel
+                ::select(['permissions.*', 'permission_role.created_at as pivot_created_at', 'permission_role.updated_at as pivot_updated_at'])
+                ->join('permission_role', 'permission_role.permission_id', '=', 'permissions.id')
+                ->join($roleTable, $roleTable . '.id', '=', 'permission_role.role_id')
+                ->whereIn($roleTable . '.id', $this->getRoles()->pluck('id')->toArray())
+                ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'permissions.deleted_at', 'pivot_created_at', 'pivot_updated_at']);
+        }
     }
 
     /**

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -199,7 +199,7 @@ trait HasRoleAndPermission
             throw new InvalidArgumentException('[roles.models.permission] must be an instance of \Illuminate\Database\Eloquent\Model');
         }
 
-        if(config('roles.inheritance')) {
+        if (config('roles.inheritance')) {
             return $permissionModel
                 ::select(['permissions.*', 'permission_role.created_at as pivot_created_at', 'permission_role.updated_at as pivot_updated_at'])
                 ->join('permission_role', 'permission_role.permission_id', '=', 'permissions.id')

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -207,8 +207,8 @@ trait HasRoleAndPermission
                 ->whereIn($roleTable . '.id', $this->getRoles()->pluck('id')->toArray())
                 ->orWhere($roleTable . '.level', '<', $this->level())
                 ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'permissions.deleted_at', 'pivot_created_at', 'pivot_updated_at']);
-        }
-        else
+        } 
+        else 
         {
             return $permissionModel
                 ::select(['permissions.*', 'permission_role.created_at as pivot_created_at', 'permission_role.updated_at as pivot_updated_at'])

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -52,6 +52,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Inheritance
+    |--------------------------------------------------------------------------
+    |
+    | By default, the plugin is configured so that all roles inherit all
+    | permissions applied to roles defined at a lower level than the role in
+    | question. If this is not desired, setting the below to false will disable
+    | this inheritance
+    |
+    */
+
+    'inheritance' => env('ROLES_INHERITANCE', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Roles, Permissions and Allowed "Pretend"
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
For complex web apps, it is not uncommon to have a large number of roles, which might be broken down into levels as allowed by this plugin for ease of access. However, in this case it might not be desirable that a user assigned a particular role at a higher level is granted all of the permissions of every role contained at a lower level. To facilitate this, this pull request implements an 'inheritance' flag in the config file, which allows for the enabling or disabling of this functionality (as provided by the rolePermissions method of the HasRoleAndPermission trait). It also includes slight language cleanup in the README section pertaining to this functionality.