### PR TITLE
Update VerifyRole.php

### DIFF
--- a/src/App/Http/Middleware/VerifyRole.php
+++ b/src/App/Http/Middleware/VerifyRole.php
@@ -37,9 +37,12 @@ class VerifyRole
      */
     public function handle($request, Closure $next, $role)
     {
-        if ($this->auth->check() && $this->auth->user()->hasRole($role)) {
-            return $next($request);
-        }
+        $roles = explode("|", $role);
+        for($i = 0; $i < count($roles); ++$i) {
+            if ($this->auth->check() && $this->auth->user()->hasRole($roles[$i])) {
+                return $next($request);
+            }            
+        }      
 
         throw new RoleDeniedException($role);
     }


### PR DESCRIPTION
Allow using | as a separator in the role verification to act as an "or" so we can check two or more roles in the routes like:
Route::resource('collaborators', CollaboratorController::class)->middleware('role:admin|gerente');