### PR TITLE
Add optional prefix to GUI routes

### DIFF
--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -19,6 +19,18 @@ return [
     'permissionsTable'      => env('ROLES_PERMISSIONS_DATABASE_TABLE', 'permissions'),
     'permissionsRoleTable'  => env('ROLES_PERMISSION_ROLE_DATABASE_TABLE', 'permission_role'),
     'permissionsUserTable'  => env('ROLES_PERMISSION_USER_DATABASE_TABLE', 'permission_user'),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | GUI routes custom prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you can add custom prefix to web routes accessing the GUI CRUD
+    | interface.
+    |
+    */
+
+    'GUIRoutesPrefix'           => env('ROLES_GUI_ROUTES_PREFIX', ''),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -10,6 +10,7 @@ Route::group([
     'middleware'    => ['web'],
     'as'            => 'laravelroles::',
     'namespace'     => 'jeremykenedy\LaravelRoles\App\Http\Controllers',
+    'prefix'        => config('roles.GUIRoutesPrefix'),
 ], function () {
 
     // Dashboards and CRUD Routes


### PR DESCRIPTION
Makes a config option to add a prefix to GUI routes.  If we only override the default routes to add a prefix, we get a LogicException when using `php artisan route:cache` .

The config option is set in the `.env` file using `ROLES_GUI_ROUTES_PREFIX`.

```
   LogicException

  Unable to prepare route [prefix/roles] for serialization. Another route has already been assigned name [laravelroles::roles.index].
```