### PR TITLE
Fix VerifyRole and VerifyPermission to work with comma separated values

### DIFF
--- a/src/App/Http/Middleware/VerifyPermission.php
+++ b/src/App/Http/Middleware/VerifyPermission.php
@@ -35,8 +35,9 @@ class VerifyPermission
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $permission)
+    public function handle($request, Closure $next, ...$permission)
     {
+        $permission = join(',', $permission);
         if ($this->auth->check() && $this->auth->user()->hasPermission($permission)) {
             return $next($request);
         }

--- a/src/App/Http/Middleware/VerifyRole.php
+++ b/src/App/Http/Middleware/VerifyRole.php
@@ -35,13 +35,11 @@ class VerifyRole
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $role)
+    public function handle($request, Closure $next, ...$role)
     {
-        $roles = explode('|', $role);
-        for ($i = 0; $i < count($roles); $i++) {
-            if ($this->auth->check() && $this->auth->user()->hasRole($roles[$i])) {
-                return $next($request);
-            }
+        $role = join(',', $role);
+        if ($this->auth->check() && $this->auth->user()->hasRole($role)) {
+            return $next($request);
         }
 
         throw new RoleDeniedException($role);


### PR DESCRIPTION
due to middleware parameters
https://laravel.com/docs/8.x/middleware#middleware-parameters