### PR TITLE
fixed: allow to override route middlewares via Kernel

### DIFF
--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -31,9 +31,12 @@ class RolesServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['router']->aliasMiddleware('role', VerifyRole::class);
-        $this->app['router']->aliasMiddleware('permission', VerifyPermission::class);
-        $this->app['router']->aliasMiddleware('level', VerifyLevel::class);
+        if (config('roles.route_middlewares', true)) {
+            $this->app['router']->aliasMiddleware('role', VerifyRole::class);
+            $this->app['router']->aliasMiddleware('permission', VerifyPermission::class);
+            $this->app['router']->aliasMiddleware('level', VerifyLevel::class);
+        }
+
         if (config('roles.rolesGuiEnabled')) {
             $this->loadRoutesFrom(__DIR__.'/routes/web.php');
         }

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -246,4 +246,12 @@ return [
     */
 
     'laravelUsersEnabled'           => env('ROLES_GUI_LARAVEL_ROLES_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Register 'role', 'permission', 'level' route middlewares
+    |--------------------------------------------------------------------------
+    */
+
+    'route_middlewares' => true,
 ];


### PR DESCRIPTION
Currently to override middlewares need to use provider as Kernel@syncMiddlewareToRouter called much earlier