### PR TITLE
n+1 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ packages/
 npm-debug.log
 yarn-error.log
 
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_KEY" value="base64:17D5MHqbPTIPEHCFqyaari5C7wKMoSceYyvwEXorYuI="/>
-        <env name="APP_ENV" value="testing"/>
-        <env name="DB_CONNECTION" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_KEY" value="base64:17D5MHqbPTIPEHCFqyaari5C7wKMoSceYyvwEXorYuI="/>
+    <env name="APP_ENV" value="testing"/>
+    <env name="DB_CONNECTION" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+  </php>
 </phpunit>

--- a/src/Database/Seeders/DefaultConnectRelationshipsSeeder.php
+++ b/src/Database/Seeders/DefaultConnectRelationshipsSeeder.php
@@ -24,10 +24,13 @@ class DefaultConnectRelationshipsSeeder extends Seeder
         $roleAdmin = config('roles.models.role')::where('slug', '=', 'admin')->first()
             ?? config('roles.models.role')::where('name', '=', 'Admin')->first();
 
-        echo "\e[32mSeeding:\e[0m DefaultConnectRelationshipsSeeder\r\n";
+        $this->command->getOutput()->writeln("<info>Seeding:</info> DefaultConnectRelationshipsSeeder");
         foreach ($permissions as $permission) {
             $roleAdmin->attachPermission($permission);
-            echo "\e[32mSeeding:\e[0m DefaultConnectRelationshipsSeeder - Role:Admin attached to Permission:".$permission->slug."\r\n";
+            $this->command->getOutput()->writeln(
+                "<info>Seeding:</info> DefaultConnectRelationshipsSeeder - Role:Admin attached to Permission:"
+                    . $permission->slug
+            );
         }
     }
 }

--- a/src/Database/Seeders/DefaultConnectRelationshipsSeeder.php
+++ b/src/Database/Seeders/DefaultConnectRelationshipsSeeder.php
@@ -29,7 +29,7 @@ class DefaultConnectRelationshipsSeeder extends Seeder
             $roleAdmin->attachPermission($permission);
             $this->command->getOutput()->writeln(
                 "<info>Seeding:</info> DefaultConnectRelationshipsSeeder - Role:Admin attached to Permission:"
-                    . $permission->slug
+                . $permission->slug
             );
         }
     }

--- a/src/Database/Seeders/DefaultPermissionsTableSeeder.php
+++ b/src/Database/Seeders/DefaultPermissionsTableSeeder.php
@@ -61,7 +61,7 @@ class DefaultPermissionsTableSeeder extends Seeder
                 ]);
                 $this->command->getOutput()->writeln(
                     "<info>Seeding:</info> DefaultPermissionitemsTableSeeder - Permission:"
-                        . $Permissionitem['slug']
+                    . $Permissionitem['slug']
                 );
             }
         }

--- a/src/Database/Seeders/DefaultPermissionsTableSeeder.php
+++ b/src/Database/Seeders/DefaultPermissionsTableSeeder.php
@@ -48,9 +48,10 @@ class DefaultPermissionsTableSeeder extends Seeder
          * Add Permission Items
          *
          */
-        echo "\e[32mSeeding:\e[0m DefaultPermissionitemsTableSeeder\r\n";
+        $this->command->getOutput()->writeln("<info>Seeding:</info> DefaultPermissionitemsTableSeeder");
         foreach ($Permissionitems as $Permissionitem) {
-            $newPermissionitem = config('roles.models.permission')::where('slug', '=', $Permissionitem['slug'])->first();
+            $newPermissionitem = config('roles.models.permission')::where('slug', '=', $Permissionitem['slug'])
+                ->first();
             if ($newPermissionitem === null) {
                 $newPermissionitem = config('roles.models.permission')::create([
                     'name'          => $Permissionitem['name'],
@@ -58,7 +59,10 @@ class DefaultPermissionsTableSeeder extends Seeder
                     'description'   => $Permissionitem['description'],
                     'model'         => $Permissionitem['model'],
                 ]);
-                echo "\e[32mSeeding:\e[0m DefaultPermissionitemsTableSeeder - Permission:".$Permissionitem['slug']."\r\n";
+                $this->command->getOutput()->writeln(
+                    "<info>Seeding:</info> DefaultPermissionitemsTableSeeder - Permission:"
+                        . $Permissionitem['slug']
+                );
             }
         }
     }

--- a/src/Database/Seeders/DefaultRolesTableSeeder.php
+++ b/src/Database/Seeders/DefaultRolesTableSeeder.php
@@ -42,7 +42,7 @@ class DefaultRolesTableSeeder extends Seeder
          * Add Role Items
          *
          */
-        echo "\e[32mSeeding:\e[0m DefaultRoleItemsTableSeeder\r\n";
+        $this->command->getOutput()->writeln("<info>Seeding:</info> DefaultRoleItemsTableSeeder");
         foreach ($RoleItems as $RoleItem) {
             $newRoleItem = config('roles.models.role')::where('slug', '=', $RoleItem['slug'])->first();
             if ($newRoleItem === null) {
@@ -52,7 +52,9 @@ class DefaultRolesTableSeeder extends Seeder
                     'description'   => $RoleItem['description'],
                     'level'         => $RoleItem['level'],
                 ]);
-                echo "\e[32mSeeding:\e[0m DefaultRoleItemsTableSeeder - Role:".$RoleItem['slug']."\r\n";
+                $this->command->getOutput()->writeln(
+                    "<info>Seeding:</info> DefaultRoleItemsTableSeeder - Role:" . $RoleItem['slug']
+                );
             }
         }
     }

--- a/src/Database/Seeders/DefaultUsersTableSeeder.php
+++ b/src/Database/Seeders/DefaultUsersTableSeeder.php
@@ -21,7 +21,7 @@ class DefaultUsersTableSeeder extends Seeder
          * Add Users
          *
          */
-        echo "\e[32mSeeding:\e[0m DefaultUsersTableSeeder\r\n";
+        $this->command->getOutput()->writeln("<info>Seeding:</info> DefaultUsersTableSeeder");
 
         if (config('roles.models.defaultUser')::where('email', '=', 'admin@admin.com')->first() === null) {
             $newUser = config('roles.models.defaultUser')::create([
@@ -34,7 +34,9 @@ class DefaultUsersTableSeeder extends Seeder
             foreach ($permissions as $permission) {
                 $newUser->attachPermission($permission);
             }
-            echo "\e[32mSeeding:\e[0m DefaultUsersTableSeeder - User:admin@admin.com\r\n";
+            $this->command->getOutput()->writeln(
+                "<info>Seeding:</info> DefaultUsersTableSeeder - User:admin@admin.com"
+            );
         }
 
         if (config('roles.models.defaultUser')::where('email', '=', 'user@user.com')->first() === null) {
@@ -45,7 +47,7 @@ class DefaultUsersTableSeeder extends Seeder
             ]);
 
             $newUser->attachRole($userRole);
-            echo "\e[32mSeeding:\e[0m DefaultUsersTableSeeder - User:user@user.com\r\n";
+            $this->command->getOutput()->writeln("<info>Seeding:</info> DefaultUsersTableSeeder - User:user@user.com");
         }
     }
 }

--- a/src/Database/TestMigrations/create_users_table.php
+++ b/src/Database/TestMigrations/create_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/src/Database/TestMigrations/create_users_table.php
+++ b/src/Database/TestMigrations/create_users_table.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\TestMigrations;
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/Database/TestMigrations/create_users_table.php
+++ b/src/Database/TestMigrations/create_users_table.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\TestMigrations;
+namespace jeremykenedy\LaravelRoles\Database\TestMigrations;
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/src/RolesServiceProvider.php
+++ b/src/RolesServiceProvider.php
@@ -77,29 +77,32 @@ class RolesServiceProvider extends ServiceProvider
      */
     private function loadSeedsFrom()
     {
-        if (config('roles.defaultSeeds.PermissionsTableSeeder')) {
-            $this->app['seed.handler']->register(
-                DefaultPermissionsTableSeeder::class
-            );
-        }
+        $this->app->afterResolving('seed.handler', function ($handler) {
+            if (config('roles.defaultSeeds.PermissionsTableSeeder')) {
+                $handler->register(
+                    DefaultPermissionsTableSeeder::class
+                );
+            }
 
-        if (config('roles.defaultSeeds.RolesTableSeeder')) {
-            $this->app['seed.handler']->register(
-                DefaultRolesTableSeeder::class
-            );
-        }
+            if (config('roles.defaultSeeds.RolesTableSeeder')) {
+                $handler->register(
+                    DefaultRolesTableSeeder::class
+                );
+            }
 
-        if (config('roles.defaultSeeds.ConnectRelationshipsSeeder')) {
-            $this->app['seed.handler']->register(
-                DefaultConnectRelationshipsSeeder::class
-            );
-        }
+            if (config('roles.defaultSeeds.ConnectRelationshipsSeeder')) {
+                $handler->register(
+                    DefaultConnectRelationshipsSeeder::class
+                );
+            }
 
-        if (config('roles.defaultSeeds.UsersTableSeeder')) {
-            $this->app['seed.handler']->register(
-                DefaultUsersTableSeeder::class
-            );
-        }
+            if (config('roles.defaultSeeds.UsersTableSeeder')) {
+                $handler->register(
+                    DefaultUsersTableSeeder::class
+                );
+            }
+        });
+
     }
 
     /**

--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace jeremykenedy\LaravelRoles\Test\Feature;
+
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use jeremykenedy\LaravelRoles\Test\RefreshDatabase;
+use jeremykenedy\LaravelRoles\Test\TestCase;
+use jeremykenedy\LaravelRoles\Test\User;
+
+class NPlusOneQueriesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected $usersCount = 10;
+    protected $rolesCount = 3;
+    protected $permissionsCount = 4;
+
+    protected $queries = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertEquals($this->rolesCount, config('roles.models.role')::count());
+        $this->assertEquals($this->permissionsCount, config('roles.models.permission')::count());
+
+        DB::listen(function (QueryExecuted $query) {
+            $this->queries++;
+        });
+    }
+
+    /** @test */
+    public function can_preload_roles_on_collection(): void
+    {
+        $roleIds = config('roles.models.role')::pluck('id');
+
+        User::factory($this->usersCount)->create()
+            ->each(function (User $user) use ($roleIds) {
+                $user->roles()->attach($roleIds);
+            });
+        $this->assertEquals($this->usersCount, User::count());
+
+        $this->queries = 0;
+
+        // without eager load
+        $users = User::get();
+        $this->assertQueries(1);
+
+        $users->each(function (User $user) {
+            $user->getRoles();
+        });
+        $this->assertQueries($this->usersCount);
+
+        // with eager load
+        $users = User::with('roles')->get();
+        $this->assertQueries(2);
+
+        $users->each(function (User $user) {
+            $user->getRoles();
+        });
+        $this->assertQueries(0);
+    }
+
+    /** @test */
+    public function can_attach_roles()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $roleId = config('roles.models.role')::value('id');
+
+        $this->queries = 0;
+        $user->attachRole($roleId);
+        // getRoles + attach
+        $this->assertQueries(2);
+
+        $this->queries = 0;
+        $user->detachAllRoles();
+        $user->attachRole($roleId);
+        // detach + getRoles + attach
+        $this->assertQueries(3);
+    }
+
+    /** @test */
+    public function it_caches_roles()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $this->queries = 0;
+        $user->getRoles();
+        $this->assertQueries(1);
+
+        $user->getRoles();
+        $this->assertQueries(0);
+
+        $user->roles;
+        $this->assertQueries(0);
+    }
+
+    /** @test */
+    public function it_caches_permissions()
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $roleIds = config('roles.models.role')::pluck('id');
+        $user->roles()->attach($roleIds);
+
+        $this->queries = 0;
+        $user->getPermissions();
+        // rolePermissions(+getRoles) + userPermissions
+        $this->assertQueries(3);
+
+        $user->getPermissions();
+        $this->assertQueries(0);
+
+        $user->permissions;
+        $this->assertQueries(0);
+
+        /** @var User $user */
+        $user = User::find($user->id);
+
+        $this->queries = 0;
+        $user->getRoles();
+        $this->assertQueries(1);
+        $user->getPermissions();
+        // rolePermissions + userPermissions
+        $this->assertQueries(2);
+    }
+
+    /** @test */
+    public function can_preload_permissions_on_collection(): void
+    {
+        $roleIds = config('roles.models.role')::pluck('id');
+
+        User::factory($this->usersCount)->create()
+            ->each(function (User $user) use ($roleIds) {
+                $user->roles()->attach($roleIds);
+            });
+        $this->assertEquals($this->usersCount, User::count());
+
+        $this->queries = 0;
+
+        // without eager load
+        $users = User::get();
+        $this->assertQueries(1);
+
+        $users->each(function (User $user) {
+            $user->getPermissions();
+        });
+        // rolePermissions(+getRoles) + userPermissions
+        $this->assertQueries($this->usersCount * 3);
+
+        // with eager load
+        // TODO: 'rolePermissions' relation
+        $users = User::with('roles', 'userPermissions')->get();
+        $this->assertQueries(3);
+
+        $users->each(function (User $user) {
+            $user->getPermissions();
+        });
+        // TODO: optimize via rolePermissions
+        $this->assertQueries(20);
+        // $this->assertQueries(0);
+    }
+
+    protected function assertQueries(int $count): void
+    {
+        $this->assertEquals($count, $this->queries);
+        $this->queries = 0;
+    }
+}

--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -33,7 +33,7 @@ class NPlusOneQueriesTest extends TestCase
     }
 
     /** @test */
-    public function can_preload_roles_on_collection(): void
+    public function canPreloadRolesOnCollection(): void
     {
         $roleIds = config('roles.models.role')::pluck('id');
 
@@ -65,7 +65,7 @@ class NPlusOneQueriesTest extends TestCase
     }
 
     /** @test */
-    public function can_attach_roles()
+    public function canAttachRoles()
     {
         /** @var User $user */
         $user = User::factory()->create();
@@ -84,7 +84,7 @@ class NPlusOneQueriesTest extends TestCase
     }
 
     /** @test */
-    public function it_caches_roles()
+    public function itCachesRoles()
     {
         /** @var User $user */
         $user = User::factory()->create();
@@ -101,7 +101,7 @@ class NPlusOneQueriesTest extends TestCase
     }
 
     /** @test */
-    public function it_caches_permissions()
+    public function itCachesPermissions()
     {
         /** @var User $user */
         $user = User::factory()->create();
@@ -131,7 +131,7 @@ class NPlusOneQueriesTest extends TestCase
     }
 
     /** @test */
-    public function can_preload_permissions_on_collection(): void
+    public function canPreloadPermissionsOnCollection(): void
     {
         $roleIds = config('roles.models.role')::pluck('id');
 
@@ -161,7 +161,7 @@ class NPlusOneQueriesTest extends TestCase
         $users->each(function (User $user) {
             $user->getPermissions();
         });
-        // TODO: optimize via rolePermissions
+        // TODO: optimize via relations: userPermissions and rolePermissions
         $this->assertQueries(20);
         // $this->assertQueries(0);
     }

--- a/tests/RefreshDatabase.php
+++ b/tests/RefreshDatabase.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace jeremykenedy\LaravelRoles\Test;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase as TestingRefreshDatabase;
+
+trait RefreshDatabase
+{
+    use TestingRefreshDatabase;
+
+    protected $seeder = [
+        \jeremykenedy\LaravelRoles\Database\Seeders\DefaultPermissionsTableSeeder::class,
+        \jeremykenedy\LaravelRoles\Database\Seeders\DefaultRolesTableSeeder::class,
+        \jeremykenedy\LaravelRoles\Database\Seeders\DefaultConnectRelationshipsSeeder::class,
+    ];
+
+    /**
+     * Refresh the in-memory database.
+     *
+     * @return void
+     */
+    protected function refreshInMemoryDatabase()
+    {
+        $this->artisan('migrate', $this->migrateUsing());
+
+        if ($this->shouldSeed()) {
+            $options = ['--force' => true];
+
+            if ($seeders = $this->seeder()) {
+                if (is_array($seeders)) {
+                    foreach ($seeders as $seeder) {
+                        $options['--class'] = $seeder;
+                        $this->artisan('db:seed', $options);
+                    }
+                } else {
+                    $options['--class'] = $seeders;
+                    $this->artisan('db:seed', $options);
+                }
+            } else {
+                $this->artisan('db:seed', $options);
+            }
+        }
+
+        $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    /**
+     * The parameters that should be used when running "migrate".
+     *
+     * @return array
+     */
+    protected function migrateUsing()
+    {
+        return [
+            /**
+             * Non standard path
+             *
+             * $this->laravel->databasePath().DIRECTORY_SEPARATOR.'migrations'
+             * with `vendor/orchestra/testbench-core/laravel` as basePath
+             *
+             * @see \Illuminate\Database\Console\Migrations\BaseCommand
+             */
+            '--path' => realpath(__DIR__ . '/../src/Database/Migrations'),
+            '--realpath' => true,
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,32 +5,51 @@ namespace jeremykenedy\LaravelRoles\Test;
 use jeremykenedy\LaravelRoles\RolesFacade;
 use jeremykenedy\LaravelRoles\RolesServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Seedster\Handlers\SeedHandler;
 
 class TestCase extends OrchestraTestCase
 {
     /**
-     * Load package service provider.
+     * Get package providers.
      *
-     * @param \Illuminate\Foundation\Application $app
+     * @param  \Illuminate\Foundation\Application  $app
      *
-     * @return jeremykenedy\LaravelRoles\RolesServiceProvider
+     * @return array<int, class-string>
      */
-    protected function getPackageProviders($app): void
+    protected function getPackageProviders($app)
     {
         return [RolesServiceProvider::class];
     }
 
     /**
-     * Load package alias.
+     * Get package aliases.
      *
-     * @param \Illuminate\Foundation\Application $app
+     * @param  \Illuminate\Foundation\Application  $app
      *
-     * @return array
+     * @return array<string, class-string>
      */
-    protected function getPackageAliases($app): void
+    protected function getPackageAliases($app)
     {
         return [
             'laravelroles' => RolesFacade::class,
         ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    public function getEnvironmentSetUp($app)
+    {
+        $app->singleton('seed.handler', function ($app) {
+            return new SeedHandler($app, collect());
+        });
+
+        include_once __DIR__ . '/../src/Database/TestMigrations/create_users_table.php';
+
+        (new \CreateUsersTable())->up();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,6 +50,6 @@ class TestCase extends OrchestraTestCase
 
         include_once __DIR__ . '/../src/Database/TestMigrations/create_users_table.php';
 
-        (new \CreateUsersTable())->up();
+        (new \Database\TestMigrations\CreateUsersTable())->up();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,6 +50,6 @@ class TestCase extends OrchestraTestCase
 
         include_once __DIR__ . '/../src/Database/TestMigrations/create_users_table.php';
 
-        (new \Database\TestMigrations\CreateUsersTable())->up();
+        (new \jeremykenedy\LaravelRoles\Database\TestMigrations\CreateUsersTable())->up();
     }
 }

--- a/tests/User.php
+++ b/tests/User.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace jeremykenedy\LaravelRoles\Test;
+
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use jeremykenedy\LaravelRoles\Traits\HasRoleAndPermission;
+
+class User extends Model implements AuthorizableContract, AuthenticatableContract
+{
+    use Authorizable;
+    use Authenticatable;
+    use HasFactory;
+    use HasRoleAndPermission;
+
+    protected $guarded = [];
+
+    protected $table = 'users';
+
+    protected static function newFactory()
+    {
+        return UserFactory::new();
+    }
+}

--- a/tests/UserFactory.php
+++ b/tests/UserFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace jeremykenedy\LaravelRoles\Test;
+
+use Orchestra\Testbench\Factories\UserFactory as TestbenchUserFactory;
+
+class UserFactory extends TestbenchUserFactory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+}


### PR DESCRIPTION
Note:
- Replaced `echo` in seeders with command output
- Deferred seeders registration after resolving `seed.handler` to prevent errors
- Updated legacy `phpunit.xml`

Still cannot reproduce #179

Detected problem: cannot preload `rolePermissions` and `userPermissions`. `rolePermissions` is not relation at all and cannot be preloaded via eager load