### PR TITLE
Change variable name used in show.blade.php

### DIFF
--- a/src/resources/views/laravelroles/crud/permissions/show.blade.php
+++ b/src/resources/views/laravelroles/crud/permissions/show.blade.php
@@ -110,16 +110,16 @@
                                 {!! trans('laravelroles::laravelroles.cards.permission-info-card.permission-desc') !!}
                                 <span class="badge badge-pill">
                                     @isset($typeDeleted)
-                                        @if($item->desc)
-                                            {{ $item->desc }}
+                                        @if($item->description)
+                                            {{ $item->description }}
                                         @else
                                             <span class="text-muted">
                                                 {!! trans('laravelroles::laravelroles.cards.permission-info-card.none') !!}
                                             </span>
                                         @endif
                                     @else
-                                        @if($item['permission']->desc)
-                                            {{ $item['permission']->desc }}
+                                        @if($item['permission']->description)
+                                            {{ $item['permission']->description }}
                                         @else
                                             <span class="text-muted">
                                                 {!! trans('laravelroles::laravelroles.cards.permission-info-card.none') !!}

--- a/src/resources/views/laravelroles/crud/roles/show.blade.php
+++ b/src/resources/views/laravelroles/crud/roles/show.blade.php
@@ -81,8 +81,8 @@
                             <li class="list-group-item d-flex justify-content-between align-items-center">
                                 {!! trans('laravelroles::laravelroles.cards.role-info-card.role-desc') !!}
                                 <span class="badge badge-pill">
-                                    @if($item->desc)
-                                        {{ $item->desc }}
+                                    @if($item->description)
+                                        {{ $item->description }}
                                     @else
                                         <span class="text-muted">
                                             {!! trans('laravelroles::laravelroles.cards.role-info-card.none') !!}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29900150/230262988-44390e6d-1896-4ded-b542-5a412af24a3e.png)
Role and permission description not showing

![image](https://user-images.githubusercontent.com/29900150/230263219-b7430a3e-4040-4faf-a42e-8eb7fbf26f62.png)
Upon further inspection of the code, it seems that the variable used to call desc is not correct.
This pull request changes those desc to description