### PR TITLE
Fix tests when $this->call(UsersTableSeeder::class) runs

### DIFF
--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -16,12 +16,12 @@ class NPlusOneQueriesTest extends TestCase
 
     protected $usersCount = 10;
     /**
-     * @var int $usersCountCorrection in case UsersTableSeeder seeds your users,
-     * please indicate their number here
+     * @var int in case UsersTableSeeder seeds your users,
+     *          please indicate their number here
      */
     protected $usersCountCorrection = 0;
-    protected $rolesCount = 3;//correct according to your data
-    protected $permissionsCount = 4;//correct according to your data
+    protected $rolesCount = 3; //correct according to your data
+    protected $permissionsCount = 4; //correct according to your data
 
     protected $queries = 0;
 

--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -15,8 +15,13 @@ class NPlusOneQueriesTest extends TestCase
     protected $seed = true;
 
     protected $usersCount = 10;
-    protected $rolesCount = 3;
-    protected $permissionsCount = 4;
+    /**
+     * @var int $usersCountCorrection in case UsersTableSeeder seeds your users,
+     * please indicate their number here
+     */
+    protected $usersCountCorrection = 0;
+    protected $rolesCount = 3;//correct according to your data
+    protected $permissionsCount = 4;//correct according to your data
 
     protected $queries = 0;
 
@@ -41,7 +46,8 @@ class NPlusOneQueriesTest extends TestCase
             ->each(function (User $user) use ($roleIds) {
                 $user->roles()->attach($roleIds);
             });
-        $this->assertEquals($this->usersCount, User::count());
+        $this->assertEquals($this->usersCount,
+            User::count() - $this->usersCountCorrection);
 
         $this->queries = 0;
 
@@ -52,6 +58,7 @@ class NPlusOneQueriesTest extends TestCase
         $users->each(function (User $user) {
             $user->getRoles();
         });
+        $this->queries = $this->queries - $this->usersCountCorrection;
         $this->assertQueries($this->usersCount);
 
         // with eager load
@@ -139,7 +146,7 @@ class NPlusOneQueriesTest extends TestCase
             ->each(function (User $user) use ($roleIds) {
                 $user->roles()->attach($roleIds);
             });
-        $this->assertEquals($this->usersCount, User::count());
+        $this->assertEquals($this->usersCount, User::count() - $this->usersCountCorrection);
 
         $this->queries = 0;
 
@@ -151,7 +158,7 @@ class NPlusOneQueriesTest extends TestCase
             $user->getPermissions();
         });
         // rolePermissions(+getRoles) + userPermissions
-        $this->assertQueries($this->usersCount * 3);
+        $this->assertQueries(($this->usersCount + $this->usersCountCorrection) * 3);
 
         // with eager load
         // TODO: 'rolePermissions' relation
@@ -162,7 +169,7 @@ class NPlusOneQueriesTest extends TestCase
             $user->getPermissions();
         });
         // TODO: optimize via relations: userPermissions and rolePermissions
-        $this->assertQueries(20);
+        $this->assertQueries(20 + $this->usersCountCorrection * 2);
         // $this->assertQueries(0);
     }
 

--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -32,7 +32,7 @@ class NPlusOneQueriesTest extends TestCase
         $this->assertEquals($this->rolesCount, config('roles.models.role')::count());
         $this->assertEquals($this->permissionsCount, config('roles.models.permission')::count());
 
-        DB::listen(function (QueryExecuted $query) {
+        DB::listen(function(QueryExecuted $query) {
             $this->queries++;
         });
     }
@@ -43,7 +43,7 @@ class NPlusOneQueriesTest extends TestCase
         $roleIds = config('roles.models.role')::pluck('id');
 
         User::factory($this->usersCount)->create()
-            ->each(function (User $user) use ($roleIds) {
+            ->each(function(User $user) use ($roleIds) {
                 $user->roles()->attach($roleIds);
             });
         $this->assertEquals($this->usersCount, User::count() - $this->usersCountCorrection);
@@ -54,7 +54,7 @@ class NPlusOneQueriesTest extends TestCase
         $users = User::get();
         $this->assertQueries(1);
 
-        $users->each(function (User $user) {
+        $users->each(function(User $user) {
             $user->getRoles();
         });
         $this->queries = $this->queries - $this->usersCountCorrection;
@@ -64,7 +64,7 @@ class NPlusOneQueriesTest extends TestCase
         $users = User::with('roles')->get();
         $this->assertQueries(2);
 
-        $users->each(function (User $user) {
+        $users->each(function(User $user) {
             $user->getRoles();
         });
         $this->assertQueries(0);
@@ -142,7 +142,7 @@ class NPlusOneQueriesTest extends TestCase
         $roleIds = config('roles.models.role')::pluck('id');
 
         User::factory($this->usersCount)->create()
-            ->each(function (User $user) use ($roleIds) {
+            ->each(function(User $user) use ($roleIds) {
                 $user->roles()->attach($roleIds);
             });
         $this->assertEquals($this->usersCount, User::count() - $this->usersCountCorrection);
@@ -153,7 +153,7 @@ class NPlusOneQueriesTest extends TestCase
         $users = User::get();
         $this->assertQueries(1);
 
-        $users->each(function (User $user) {
+        $users->each(function(User $user) {
             $user->getPermissions();
         });
         // rolePermissions(+getRoles) + userPermissions
@@ -164,7 +164,7 @@ class NPlusOneQueriesTest extends TestCase
         $users = User::with('roles', 'userPermissions')->get();
         $this->assertQueries(3);
 
-        $users->each(function (User $user) {
+        $users->each(function(User $user) {
             $user->getPermissions();
         });
         // TODO: optimize via relations: userPermissions and rolePermissions

--- a/tests/Feature/NPlusOneQueriesTest.php
+++ b/tests/Feature/NPlusOneQueriesTest.php
@@ -46,8 +46,7 @@ class NPlusOneQueriesTest extends TestCase
             ->each(function (User $user) use ($roleIds) {
                 $user->roles()->attach($roleIds);
             });
-        $this->assertEquals($this->usersCount,
-            User::count() - $this->usersCountCorrection);
+        $this->assertEquals($this->usersCount, User::count() - $this->usersCountCorrection);
 
         $this->queries = 0;
 


### PR DESCRIPTION
When DatabaseSeeder runs `$this->call(UsersTableSeeder::class)` with custom users, count assertions fails.